### PR TITLE
UX: try text style, update outlet, stick to bottom, etc

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,7 +1,24 @@
+.has-full-page-chat {
+  #discourse-site-credit-mobile,
+  .fk-d-tooltip__trigger[data-identifier="discourse-site-credit"] {
+    // doesn't work on chat due to full-height layout
+    display: none !important;
+  }
+}
+
+.admin-area {
+  #discourse-site-credit-mobile,
+  .fk-d-tooltip__trigger[data-identifier="discourse-site-credit"] {
+    display: none; // hides on admin area
+  }
+}
+
+#discourse-site-credit-mobile,
 .fk-d-tooltip__trigger[data-identifier="discourse-site-credit"] {
   display: inline-flex;
   align-items: center;
   transition: color 0.25s ease-in-out;
+  margin-left: -0.01em; // fixes tooltip position for some reason
 
   a {
     display: flex;
@@ -21,13 +38,13 @@
   }
 
   @if $style == "badge" {
+    margin-left: -0.35em;
     padding: 0.25em 0.85em 0.25em 0.5em;
     background: var(--primary-very-low);
     border-radius: 0.75em 0.75em 0.75em 0;
     color: var(--primary-medium);
     font-size: var(--font-down-1);
     letter-spacing: 0.3px;
-    margin-left: -0.35em;
 
     .discourse-site-credit__logo--color {
       display: none;
@@ -35,6 +52,7 @@
   }
 
   @if $style == "text" {
+    opacity: 0.8;
     a {
       color: var(--primary-high);
     }
@@ -45,27 +63,40 @@
 
     .discourse-site-credit__logo--color {
       position: relative;
-      top: 0.15em;
+      top: 0.2em;
       display: inline-block;
       width: 1em;
       height: 1em;
       background-image: var(--discourse-logo);
       background-size: cover;
+      transition: opacity 0.25s ease-in-out, filter 0.25s ease-in-out;
+      .discourse-no-touch & {
+        filter: saturate(0);
+      }
+    }
+
+    &:hover {
+      opacity: 1;
+      .discourse-no-touch & {
+        .discourse-site-credit__logo--color {
+          filter: saturate(1);
+        }
+      }
     }
   }
 }
 
-[data-identifier="discourse-site-credit"] {
-  margin-top: 0.5em;
-}
-
-.more-topics__container + [data-identifier="discourse-site-credit"] {
-  position: relative;
-  top: -0.5em; // more consistent spacing
-  margin-top: 0;
-  margin-bottom: 0.15em;
+#discourse-site-credit-mobile,
+.fk-d-tooltip__trigger[data-identifier="discourse-site-credit"] {
+  position: absolute;
+  bottom: 1em;
 }
 
 #d-tooltip-portal-outlet [data-identifier="discourse-site-credit"] {
   font-size: var(--font-down-1);
+}
+
+body[class*="archetype"] #main-outlet {
+  // avoids overlap in topics
+  padding-bottom: 2em;
 }

--- a/javascripts/discourse/components/site-credit.gjs
+++ b/javascripts/discourse/components/site-credit.gjs
@@ -1,23 +1,22 @@
 import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
 import icon from "discourse-common/helpers/d-icon";
 import i18n from "discourse-common/helpers/i18n";
 import DTooltip from "float-kit/components/d-tooltip";
 
 export default class SiteCredit extends Component {
-  get encodedRef() {
-    return btoa(encodeURIComponent(window.location.hostname));
+  @service site;
+
+  get encodedDomain() {
+    return btoa(window.location.hostname);
   }
 
   <template>
-    <DTooltip
-      @arrow={{true}}
-      @identifier="discourse-site-credit"
-      @placement="bottom"
-    >
-      <:trigger>
+    {{#if this.site.mobileView}}
+      <div id="discourse-site-credit-mobile">
         <a
           id="discourse-site-credit"
-          href="https://www.discourse.org/pricing?ref={{this.encodedRef}}"
+          href="https://discover.discourse.org/powered-by?ref={{this.encodedDomain}}"
           nofollow="true"
         >
           <span class="discourse-site-credit__logo--color"></span>
@@ -26,10 +25,26 @@ export default class SiteCredit extends Component {
             }}</span>
           <span>{{i18n (themePrefix "powered_by")}}</span>
         </a>
-      </:trigger>
-      <:content>
-        {{i18n (themePrefix "cta")}}
-      </:content>
-    </DTooltip>
+      </div>
+    {{else}}
+      <DTooltip @arrow={{true}} @identifier="discourse-site-credit">
+        <:trigger>
+          <a
+            id="discourse-site-credit"
+            href="https://discover.discourse.org/powered-by?ref={{this.encodedDomain}}"
+            nofollow="true"
+          >
+            <span class="discourse-site-credit__logo--color"></span>
+            <span class="discourse-site-credit__logo--icon">{{icon
+                "fab-discourse"
+              }}</span>
+            <span>{{i18n (themePrefix "powered_by")}}</span>
+          </a>
+        </:trigger>
+        <:content>
+          {{i18n (themePrefix "cta")}}
+        </:content>
+      </DTooltip>
+    {{/if}}
   </template>
 }

--- a/javascripts/discourse/initializers/init-site-credit-connector.js
+++ b/javascripts/discourse/initializers/init-site-credit-connector.js
@@ -2,6 +2,5 @@ import { apiInitializer } from "discourse/lib/api";
 import SiteCredit from "../components/site-credit";
 
 export default apiInitializer("1.14.0", (api) => {
-  api.renderAfterWrapperOutlet("topic-list-bottom", SiteCredit);
-  api.renderInOutlet("topic-below-suggested", SiteCredit);
+  api.renderInOutlet("main-outlet-bottom", SiteCredit);
 });

--- a/settings.yml
+++ b/settings.yml
@@ -1,6 +1,6 @@
 style:
   type: enum
-  default: "badge"
+  default: "text"
   choices:
     - "badge"
     - "text"


### PR DESCRIPTION
This will force the credit to the bottom of the page like so:

![image](https://github.com/discourse/discourse-site-credit-component/assets/1681963/0eea691b-6adc-46ac-aac5-db965cd36c05)

I've also updated the default so we can try the text-only version out internally, hide the credit in chat and admin, add a hover effect to the text-only version, and added a tooltip-less version for mobile. 