### PR TITLE
DEV: minor cleanup, add margin to avoid custom content

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -9,10 +9,11 @@
   font-size: var(--font-down-1);
   letter-spacing: 0.3px;
   gap: 0.33em;
-  padding: 0.133em;
+  padding: 2px;
   background: var(--primary-very-low);
   border-radius: 0.75em 0.75em 0.75em 0;
   transition: all 0.25s ease-in-out;
+  margin-bottom: 1em;
 
   .d-icon {
     position: relative;
@@ -25,7 +26,6 @@
 
   &:hover {
     color: var(--primary-high);
-
     @media (prefers-reduced-motion: no-preference) {
       background: linear-gradient(
         45deg,
@@ -41,17 +41,16 @@
         #00aeef
       );
       background-size: 300%;
-      animation: rainbow-shimmer 0.5s;
+      animation: d-rainbow-shimmer 0.5s;
       animation-iteration-count: 1;
       animation-fill-mode: forwards;
-      animation-direction: alternate;
       animation-timing-function: ease-in-out;
       animation-delay: 0.25s;
     }
   }
 }
 
-@keyframes rainbow-shimmer {
+@keyframes d-rainbow-shimmer {
   0% {
     background-position: 0% 50%;
   }
@@ -64,5 +63,5 @@
 .discourse-site-credit__content {
   background: var(--primary-very-low);
   border-radius: 0.62em 0.62em 0.62em 0;
-  padding: 0.25em 0.75em 0.25em 0.5em;
+  padding: 0.25em 0.65em 0.25em 0.5em;
 }

--- a/javascripts/discourse/components/site-credit.gjs
+++ b/javascripts/discourse/components/site-credit.gjs
@@ -17,9 +17,9 @@ export default class SiteCredit extends Component {
       nofollow="true"
     >
       <span class="discourse-site-credit__content">
-        <span class="discourse-site-credit__logo--icon">{{icon
-            "fab-discourse"
-          }}</span>
+        <span class="discourse-site-credit__logo--icon">
+          {{icon "fab-discourse"}}
+        </span>
         <span>{{i18n (themePrefix "powered_by")}}</span>
       </span>
     </a>


### PR DESCRIPTION
adds some margin below the badge so it has some space between things like custom footers 

just minor cleanup otherwise, the hover effect is more consistent with px setting the padding... prefixing the animation to avoid any possible clashing, minor padding and template adjustments... 

before:
![image](https://github.com/discourse/discourse-site-credit-component/assets/1681963/58902c4b-2333-4fda-af3a-001ff65ed4d9)

after:
![image](https://github.com/discourse/discourse-site-credit-component/assets/1681963/caad2127-d50a-492b-b326-b82b3a990edd)

(going to clean up this left alignment with the "there are 7..." text in core)