### PR TITLE
DEV: switch outlet, adjust and cleanup styles

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,39 +1,50 @@
-.more-topics__container {
-  padding-bottom: 0;
-}
-
-#discourse-site-credit {
-  display: inline-flex;
-  align-items: center;
-  color: var(--primary-medium);
+.discourse-site-credit {
+  .admin-area &,
+  .has-full-page-chat & {
+    display: none !important;
+  }
+  grid-area: below-content;
+  justify-self: start;
   font-size: var(--font-down-1);
-  letter-spacing: 0.3px;
-  gap: 0.33em;
-  padding: 0.133em;
-  background: var(--primary-very-low);
-  border-radius: 0.75em 0.75em 0.75em 0;
+  letter-spacing: 0.2px; // extra spacing makes small text easier to read
+  padding: 2px; // animated hover "border" width
+  background: var(--secondary);
+  border-radius: 0.75em;
   transition: all 0.25s ease-in-out;
+  margin-bottom: 0.45em;
+  color: var(--primary-medium);
+
+  &:visited {
+    color: var(--primary-medium);
+  }
+
+  &__content {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5em;
+    color: currentColor;
+    background: var(--secondary);
+    border-radius: 0.62em;
+    padding: 0.25em 0.65em 0.25em 0.5em;
+  }
 
   .d-icon {
     position: relative;
-    top: 0.02em; // vertical alignment
-  }
-
-  &:visted {
-    color: currentColor;
+    top: 0.05em; // vertical alignment
   }
 
   &:hover {
     color: var(--primary-high);
 
     @media (prefers-reduced-motion: no-preference) {
+      // secondary repeat is an intentional buffer
       background: linear-gradient(
         45deg,
-        var(--primary-very-low),
-        var(--primary-very-low),
-        var(--primary-very-low),
-        var(--primary-very-low),
-        var(--primary-very-low),
+        var(--secondary),
+        var(--secondary),
+        var(--secondary),
+        var(--secondary),
+        var(--secondary),
         #d0232b,
         #f15d22,
         #fff9ae,
@@ -41,12 +52,11 @@
         #00aeef
       );
       background-size: 300%;
-      animation: rainbow-shimmer 0.5s;
-      animation-iteration-count: 1;
+      animation: d-rainbow-shimmer 0.5s;
       animation-fill-mode: forwards;
       animation-direction: alternate;
       animation-timing-function: ease-in-out;
-      animation-delay: 0.25s;
+      animation-delay: 0.25s; // avoid animating on passing hover
     }
   }
 }
@@ -57,12 +67,5 @@
   }
   100% {
     background-position: 100% 50%;
-    background-size: 300%;
   }
-}
-
-.discourse-site-credit__content {
-  background: var(--primary-very-low);
-  border-radius: 0.62em 0.62em 0.62em 0;
-  padding: 0.25em 0.75em 0.25em 0.5em;
 }

--- a/javascripts/discourse/components/site-credit.gjs
+++ b/javascripts/discourse/components/site-credit.gjs
@@ -12,7 +12,7 @@ export default class SiteCredit extends Component {
 
   <template>
     <a
-      id="discourse-site-credit"
+      class="discourse-site-credit"
       href="https://discover.discourse.org/powered-by/{{this.encodedDomain}}"
       nofollow="true"
     >

--- a/javascripts/discourse/initializers/init-site-credit-connector.js
+++ b/javascripts/discourse/initializers/init-site-credit-connector.js
@@ -2,6 +2,5 @@ import { apiInitializer } from "discourse/lib/api";
 import SiteCredit from "../components/site-credit";
 
 export default apiInitializer("1.14.0", (api) => {
-  api.renderAfterWrapperOutlet("topic-list-bottom", SiteCredit);
-  api.renderInOutlet("topic-below-suggested", SiteCredit);
+  api.renderInOutlet("after-main-outlet", SiteCredit);
 });


### PR DESCRIPTION
This updates the positioning to be consistent on every page, and simplifies and cleans up styling 

text-only by default 

![image](https://github.com/discourse/discourse-site-credit-component/assets/1681963/f49ecc72-8cc6-4f40-98e9-382ea7cdd906)

rainbow badge on hover 

![image](https://github.com/discourse/discourse-site-credit-component/assets/1681963/67f6f6fb-c104-4785-8b31-edcd5077ec09)


